### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compile": "babel -d dist/ src/",
     "prepublish": "npm test && npm run compile",
     "build": ":",
-    "release": "npm install @wix/wnpm-ci && wnpm-release -- --no-shrinkwrap"
+    "release": "npm install wnpm-ci && wnpm-release -- --no-shrinkwrap"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit suggests a fix for package.json. When running npm install
user gets an error that @wix/wnpm-ci package could not be found. It is
fixed by just using wnpm-ci instead of @wix/wnpm-ci.