### PR TITLE
Normalize locale input format before matching, fix #3

### DIFF
--- a/src/FacebookLocales.js
+++ b/src/FacebookLocales.js
@@ -60,6 +60,14 @@ const localesToNonStandardFacebookLocales = _(facebookVirtualLocales)
 	.value()
 
 export const bestFacebookLocaleFor = locale => {
+	// Normalize locale input format
+	if (locale.includes('-')) {
+		locale = locale.replace('-', '_');
+	}
+	if (locale.includes('_')) {
+		locale = locale.split('_')[0] + '_' + locale.split('_')[1].toUpperCase();
+	}
+
 	// Standard supported locales
 	if (_.includes(facebookSupportedLocales, locale)) {
 		return locale


### PR DESCRIPTION
- Repace `-` with `_`
- Capitalize characters after `_`

Original results looks odd in some situations:
```
> FacebookLocales.bestFacebookLocaleFor('en-IN')
'en_GB'
> FacebookLocales.bestFacebookLocaleFor('zh-TW')
'zh_CN'
```

The corrected results would be as fellow:
```
> FacebookLocales.bestFacebookLocaleFor('en-IN')
'en_IN'
> FacebookLocales.bestFacebookLocaleFor('zh-TW')
'zh_TW'
```