### PR TITLE
Remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "dependencies": {
-    "lodash": "^4.17.10"
-  },
+  "dependencies": {},
   "directories": {
     "test": "test"
   }

--- a/src/FacebookLocales.js
+++ b/src/FacebookLocales.js
@@ -1,5 +1,5 @@
 import { supportedLocales as facebookSupportedLocales } from './Facebook'
-import _ from 'lodash'
+import lodash from 'lodash'
 
 // Facebook blanket locales, mapped to real locales by common sense.
 // @see <a href='https://developers.facebook.com/docs/internationalization#locales'>Locales and Languages Supported by Facebook</a>
@@ -53,14 +53,14 @@ const facebookVirtualLocales = {
 }
 
 // Invert facebookVirtualLocales (map real locales to Facebook virtual locales)
-const localesToNonStandardFacebookLocales = _(facebookVirtualLocales)
-	.flatMap((locales, facebookNonStandardLocale) => _.map(locales, locale => [locale, facebookNonStandardLocale]))
+const localesToNonStandardFacebookLocales = lodash(facebookVirtualLocales)
+	.flatMap((locales, facebookNonStandardLocale) => lodash.map(locales, locale => [locale, facebookNonStandardLocale]))
 	.fromPairs()
 	.value()
 
 export const bestFacebookLocaleFor = locale => {
 	// Standard supported locales
-	if (_.includes(facebookSupportedLocales, locale)) {
+	if (lodash.includes(facebookSupportedLocales, locale)) {
 		return locale
 	}
 
@@ -72,7 +72,7 @@ export const bestFacebookLocaleFor = locale => {
 
 	// Unsupported locale, make an effort and return some supported locale with same langauge
 	const language = locale.substring(0, 2)
-	const supportedLocaleInLanguage = _.find(facebookSupportedLocales, supportedLocale => _.startsWith(supportedLocale, language) )
+	const supportedLocaleInLanguage = lodash.find(facebookSupportedLocales, supportedLocale => lodash.startsWith(supportedLocale, language) )
 	if (supportedLocaleInLanguage) {
 		return supportedLocaleInLanguage
 	}

--- a/src/FacebookLocales.js
+++ b/src/FacebookLocales.js
@@ -1,5 +1,4 @@
 import { supportedLocales as facebookSupportedLocales } from './Facebook'
-import lodash from 'lodash'
 
 // Facebook blanket locales, mapped to real locales by common sense.
 // @see <a href='https://developers.facebook.com/docs/internationalization#locales'>Locales and Languages Supported by Facebook</a>
@@ -53,10 +52,12 @@ const facebookVirtualLocales = {
 }
 
 // Invert facebookVirtualLocales (map real locales to Facebook virtual locales)
-const localesToNonStandardFacebookLocales = lodash(facebookVirtualLocales)
-	.flatMap((locales, facebookNonStandardLocale) => locales.map(locale => [locale, facebookNonStandardLocale]))
-	.fromPairs()
-	.value()
+const localesToNonStandardFacebookLocales = {};
+Object.keys(facebookVirtualLocales).forEach((locale) => {
+  facebookVirtualLocales[locale].reduce(( accumulator = localesToNonStandardFacebookLocales, currentValue, index) => {
+    accumulator[currentValue] = locale;
+  }, localesToNonStandardFacebookLocales);
+});
 
 export const bestFacebookLocaleFor = locale => {
 	// Standard supported locales

--- a/src/FacebookLocales.js
+++ b/src/FacebookLocales.js
@@ -54,13 +54,13 @@ const facebookVirtualLocales = {
 
 // Invert facebookVirtualLocales (map real locales to Facebook virtual locales)
 const localesToNonStandardFacebookLocales = lodash(facebookVirtualLocales)
-	.flatMap((locales, facebookNonStandardLocale) => lodash.map(locales, locale => [locale, facebookNonStandardLocale]))
+	.flatMap((locales, facebookNonStandardLocale) => locales.map(locale => [locale, facebookNonStandardLocale]))
 	.fromPairs()
 	.value()
 
 export const bestFacebookLocaleFor = locale => {
 	// Standard supported locales
-	if (lodash.includes(facebookSupportedLocales, locale)) {
+	if (facebookSupportedLocales.includes(locale)) {
 		return locale
 	}
 
@@ -72,7 +72,7 @@ export const bestFacebookLocaleFor = locale => {
 
 	// Unsupported locale, make an effort and return some supported locale with same langauge
 	const language = locale.substring(0, 2)
-	const supportedLocaleInLanguage = lodash.find(facebookSupportedLocales, supportedLocale => lodash.startsWith(supportedLocale, language) )
+	const supportedLocaleInLanguage = facebookSupportedLocales.find(supportedLocale => supportedLocale.indexOf(language) === 0)
 	if (supportedLocaleInLanguage) {
 		return supportedLocaleInLanguage
 	}


### PR DESCRIPTION
# Smaller bundle size

We noticed our bundle is importing lodash  (23.99 gzipped) because it facebook-locales is importing the entirety of `lodash` as `_`. This is an older pattern which impacts bundle size for consumers of this repo. 

<img width="886" alt="Screen Shot 2020-09-25 at 1 49 12 PM" src="https://user-images.githubusercontent.com/196199/94299700-070f9500-ff36-11ea-8913-c458c75956c7.png">

What we would prefer instead, would be for facebook-locales' usage of `lodash` to fall into the other `lodash` usages in our bundle which is tree shaken down to (4.29 gzipped) 

<img width="190" alt="Screen Shot 2020-09-25 at 1 49 54 PM" src="https://user-images.githubusercontent.com/196199/94299769-1db5ec00-ff36-11ea-89ea-48cc62ab14a1.png">

# Options 

A straightforward solution is change the imports to:

```
import map from 'lodash/map';
...
```

When I looked into the code, I saw that the majority of the usages are simple functions which are now available on array. Given that [array functions are now supported in most browsers](https://caniuse.com/array-find) (and are polly filled for those who are building for non-modern browsers) now is a good time to migrate from `lodash` to native functions. 

- [x] So rather than replacing them with a treeshakable import, I replaced the lodash usage with the array function equivalents.


# How this was tested

```
$ npm test

> facebook-locales@1.0.2 test  facebook-locales
> mocha --compilers js:babel-register



  FacebookLocales
    ✓ supports the default locale: English (United States)
    ✓ supports a standard locale: French (France)
    ✓ supports a non-standard locale: Spanish (Latin America)
    ✓ supports a non-standard locale: Arabic
    ✓ makes best effort to return a supported Facebook locale with the same langauge as an unsupported locale
    ✓ falls back to English (United States) if all else fails


  6 passing (166ms)
```

```
$ npm run compile

> facebook-locales@1.0.2 compile facebook-locales
> babel -d dist/ src/

src/Facebook.js -> dist/Facebook.js
src/FacebookLocales.js -> dist/FacebookLocales.js
src/index.js -> dist/index.js
```